### PR TITLE
Meta | Futureproofing godot project with .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Godot 4+ specific ignores
+.godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json


### PR DESCRIPTION
We do not want godot infesting our repo with their metafiles, so here is the remedy.
From https://github.com/github/gitignore/blob/main/Godot.gitignore